### PR TITLE
Decompressor/Compressor pool

### DIFF
--- a/Sources/HummingbirdCompression/Allocator.swift
+++ b/Sources/HummingbirdCompression/Allocator.swift
@@ -19,6 +19,22 @@ protocol ZlibAllocator<Value> {
     func free(_ compressor: inout Value?)
 }
 
+/// Wrapper for value that uses allocator to manage its lifecycle
+class AllocatedValue<Allocator: ZlibAllocator> {
+    let value: Allocator.Value
+    let allocator: Allocator
+
+    init(allocator: Allocator) throws {
+        self.allocator = allocator
+        self.value = try allocator.allocate()
+    }
+
+    deinit {
+        var optionalValue: Allocator.Value? = self.value
+        self.allocator.free(&optionalValue)
+    }
+}
+
 /// Type that can be used with the PoolAllocator
 protocol PoolReusable {
     func reset() throws

--- a/Sources/HummingbirdCompression/Allocator.swift
+++ b/Sources/HummingbirdCompression/Allocator.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2025 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOConcurrencyHelpers
+
+protocol ZlibAllocator<Value> {
+    associatedtype Value
+    func allocate() throws -> Value
+    func free(_ compressor: inout Value?) throws
+}
+
+protocol PoolReusable {
+    func reset() throws
+}
+
+struct PoolAllocator<BaseAllocator: ZlibAllocator>: ZlibAllocator where BaseAllocator.Value: PoolReusable {
+    typealias Value = BaseAllocator.Value
+    @usableFromInline
+    let base: BaseAllocator
+    @usableFromInline
+    let poolSize: Int
+    @usableFromInline
+    let values: NIOLockedValueBox<[Value]>
+
+    @inlinable
+    init(size: Int, base: BaseAllocator) {
+        self.base = base
+        self.poolSize = size
+        self.values = .init([])
+    }
+
+    @inlinable
+    func allocate() throws -> Value {
+        let value = self.values.withLockedValue {
+            $0.popLast()
+        }
+        if let value {
+            return value
+        }
+        return try base.allocate()
+    }
+
+    @inlinable
+    func free(_ value: inout Value?) throws {
+        guard let nonOptionalValue = value else { preconditionFailure("Cannot ball free twice on a compressor") }
+        try self.values.withLockedValue {
+            if $0.count < poolSize {
+                try nonOptionalValue.reset()
+                $0.append(nonOptionalValue)
+            }
+        }
+        try base.free(&value)
+    }
+}

--- a/Sources/HummingbirdCompression/CompressedBodyWriter.swift
+++ b/Sources/HummingbirdCompression/CompressedBodyWriter.swift
@@ -72,7 +72,8 @@ where Allocator.Value == ZlibCompressor {
             }
         }
         self.lastBuffer = nil
-        try self.allocator.free(&self.compressor)
+        
+        self.allocator.free(&self.compressor)
         try await self.parentWriter.finish(trailingHeaders)
     }
 }
@@ -103,7 +104,7 @@ struct ZlibCompressorAllocator: ZlibAllocator, Sendable {
         try ZlibCompressor(algorithm: algorithm, configuration: configuration)
     }
 
-    func free(_ compressor: inout ZlibCompressor?) throws {
+    func free(_ compressor: inout ZlibCompressor?) {
         compressor = nil
     }
 }

--- a/Sources/HummingbirdCompression/CompressedBodyWriter.swift
+++ b/Sources/HummingbirdCompression/CompressedBodyWriter.swift
@@ -72,7 +72,7 @@ where Allocator.Value == ZlibCompressor {
             }
         }
         self.lastBuffer = nil
-        
+
         self.allocator.free(&self.compressor)
         try await self.parentWriter.finish(trailingHeaders)
     }
@@ -85,12 +85,32 @@ extension ResponseBodyWriter {
     ///   - windowSize: Window size (in bytes) to use when compressing data
     ///   - logger: Logger used to output compression errors
     /// - Returns: new ``HummingbirdCore/ResponseBodyWriter``
-    func compressed(
-        compressorPool: PoolAllocator<ZlibCompressorAllocator>,
+    func compressed<Allocator: ZlibAllocator<ZlibCompressor>>(
+        compressorPool: Allocator,
         windowSize: Int,
         logger: Logger
     ) throws -> some ResponseBodyWriter {
         try CompressedBodyWriter(parent: self, allocator: compressorPool, windowSize: windowSize, logger: logger)
+    }
+
+    ///  Return ``HummingbirdCore/ResponseBodyWriter`` that compresses the contents of this ResponseBodyWriter
+    /// - Parameters:
+    ///   - algorithm: Compression algorithm
+    ///   - configuration: Zlib configuration
+    ///   - windowSize: Window size (in bytes) to use when compressing data
+    ///   - logger: Logger used to output compression errors
+    /// - Returns: new ``HummingbirdCore/ResponseBodyWriter``
+    public func compressed(
+        algorithm: ZlibAlgorithm,
+        configuration: ZlibConfiguration,
+        windowSize: Int,
+        logger: Logger
+    ) throws -> some ResponseBodyWriter {
+        try compressed(
+            compressorPool: ZlibCompressorAllocator(algorithm: algorithm, configuration: configuration),
+            windowSize: windowSize,
+            logger: logger
+        )
     }
 }
 


### PR DESCRIPTION
Add a pool of decompressors and compressors for both gzip and deflate. When middleware needs either it will use one in the pool if it exists otherwise it will allocate a new one. When freeing the compressor/decompressor it will pass it back to the pool if the pool hasn't already reached its maximum size.

This should reduce the amount of allocations made by zlib considerably